### PR TITLE
001 init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.DS_Store
+dist

--- a/README.md
+++ b/README.md
@@ -1,0 +1,58 @@
+# YouTube Transcript MCP Tool
+
+Ferramenta MCP para obter transcrições de vídeos do YouTube com timestamps e fornecer para agentes LLM. Equivalente funcional ao comportamento de `example.ts`.
+
+## Uso via npx
+```
+npx youtube-transcript-mcp --videoUrl "https://www.youtube.com/watch?v=VIDEO_ID" --preferredLanguages "pt-BR,en"
+```
+Retorna JSON no stdout com a lista de segmentos ou `null` em falha.
+
+## Configuração MCP (exemplo)
+No host MCP (ex: Claude Desktop / MCP compatível):
+```
+{
+  "mcpServers": {
+    "youtube-transcript": {
+      "command": "npx",
+      "args": ["-y", "--package=github:lucasliet/youtube-transcript-mcp#main", "youtube-transcript-mcp"],
+      "env": {}
+    }
+  }
+}
+```
+
+Alternativa (quando publicado no npm):
+```
+{
+  "mcpServers": {
+    "youtube-transcript": {
+      "command": "npx",
+      "args": ["-y", "youtube-transcript-mcp"],
+      "env": {}
+    }
+  }
+}
+```
+
+## Integração MCP (programática)
+```
+import tools from 'youtube-transcript-mcp'
+```
+`tools` é um array com a ferramenta `transcript_yt` pronta para registro no host MCP.
+
+## Desenvolvimento
+- Node 18+
+- TypeScript
+
+Scripts:
+```
+npm run build
+npm test
+```
+
+## Garantias de Projeto
+- Sem cache interno
+- Sem truncamento de resposta
+- Erros retornam `null`; logs categorizados
+- Seleção de idioma com prioridade e fallback

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,196 @@
+{
+  "name": "youtube-transcript-mcp",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "youtube-transcript-mcp",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^0.5.0"
+      },
+      "bin": {
+        "youtube-transcript-mcp": "dist/cli.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20.19.13",
+        "typescript": "^5.6.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-0.5.0.tgz",
+      "integrity": "sha512-RXgulUX6ewvxjAG0kOpLMEdXXWkzWgaoCGaA2CwNW7cQCIphjpJhjpHSiaPdVCnisjRF/0Cm9KWHUuIoeiAblQ==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "raw-body": "^3.0.0",
+        "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.13.tgz",
+      "integrity": "sha512-yCAeZl7a0DxgNVteXFHt9+uyFbqXGy/ShC4BlcHkoE0AfGXYv/BUiplV72DjMYXHDBXFjhvr6DD1NiRVfB4j8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-errors/node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
+      "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.7.0",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "youtube-transcript-mcp",
+  "version": "0.1.0",
+  "description": "MCP tool to fetch YouTube transcripts for LLMs",
+  "license": "MIT",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "bin": {
+    "youtube-transcript-mcp": "dist/cli.js"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "npm run build && node --test dist/tests/**/*.test.js",
+    "prepare": "tsc -p tsconfig.json"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "devDependencies": {
+    "@types/node": "^20.19.13",
+    "typescript": "^5.6.2"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^0.5.0"
+  }
+}

--- a/specs/001-criar-mcp-que/quickstart.md
+++ b/specs/001-criar-mcp-que/quickstart.md
@@ -2,9 +2,9 @@
 
 ## Instalação / Uso via npx
 ```
-npx youtube-transcript-mcp
+npx youtube-transcript-mcp --videoUrl "https://www.youtube.com/watch?v=VIDEO_ID" --preferredLanguages "pt-BR,en"
 ```
-(Assumindo publicação do pacote com bin configurado.)
+Retorna JSON no stdout com a lista de segmentos ou `null` em falha.
 
 ## Registro da Ferramenta no MCP Host
 Exemplo de configuração (pseudo JSON):
@@ -21,6 +21,28 @@ Exemplo de configuração (pseudo JSON):
   ]
 }
 ```
+
+Uso programático (import do pacote):
+```
+import tools from 'youtube-transcript-mcp'
+
+// tools é um array contendo ['transcript_yt', { schema, fn }]
+```
+
+## Configuração como MCP Server
+Coloque no arquivo de configuração do host MCP:
+```
+{
+  "mcpServers": {
+    "youtube-transcript": {
+      "command": "npx",
+      "args": ["-y", "--package=github:lucasliet/youtube-transcript-mcp#main", "youtube-transcript-mcp"],
+      "env": {}
+    }
+  }
+}
+```
+Este servidor utiliza `@modelcontextprotocol/sdk` e comunica via stdio.
 
 ## Chamada
 Entrada:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+import { transcriptYt } from './tool/transcriptYt.js'
+
+/**
+ * CLI/MCP entrypoint. If --videoUrl is provided, runs a one-off fetch and prints JSON.
+ * Otherwise, starts an MCP server over stdio exposing the transcript_yt tool.
+ */
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+  if (args.videoUrl) {
+    const preferredLanguages = args.preferredLanguages ? String(args.preferredLanguages).split(',').map((s) => s.trim()).filter(Boolean) : undefined
+    const res = await transcriptYt({ videoUrl: String(args.videoUrl), preferredLanguages })
+    process.stdout.write(JSON.stringify(res))
+    return
+  }
+  await startMcpServer()
+}
+
+/**
+ * Starts an MCP server over stdio with the transcript_yt tool.
+ */
+async function startMcpServer() {
+  const { Server } = await import('@modelcontextprotocol/sdk/server/index.js')
+  const { StdioServerTransport } = await import('@modelcontextprotocol/sdk/server/stdio.js')
+
+  const server = new Server({
+    name: 'youtube-transcript-mcp',
+    version: '0.1.0'
+  }, {
+    capabilities: { tools: {} }
+  })
+
+  ;(server as any).setRequestHandler('tools/list', async () => ({
+    tools: [
+      {
+        name: 'transcript_yt',
+        description: 'Fetches YouTube transcript segments from a video URL for LLM consumption.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            videoUrl: { type: 'string', description: 'Full YouTube video URL.' },
+            preferredLanguages: { type: 'array', items: { type: 'string' }, description: "Optional ordered language codes preference, e.g., ['pt-BR','en']." }
+          },
+          required: ['videoUrl'],
+          additionalProperties: false
+        }
+      }
+    ]
+  }))
+
+  ;(server as any).setRequestHandler('tools/call', async (req: any) => {
+    const name = req?.params?.name
+    const args = req?.params?.arguments || {}
+    if (name !== 'transcript_yt') {
+      return { content: [{ type: 'text', text: 'Tool not found' }], isError: true }
+    }
+    const res = await transcriptYt({
+      videoUrl: String(args.videoUrl || ''),
+      preferredLanguages: Array.isArray(args.preferredLanguages) ? args.preferredLanguages : undefined
+    })
+    return { content: [{ type: 'json', json: res }] }
+  })
+
+  const transport = new StdioServerTransport()
+  await server.connect(transport)
+}
+
+/**
+ * Parses CLI arguments into a key/value object.
+ * @param argv The argv slice (excluding node and script).
+ * @returns A map of parsed flags.
+ */
+function parseArgs(argv: string[]) {
+  const out: Record<string, string | boolean> = {}
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]
+    if (a.startsWith('--')) {
+      const k = a.slice(2)
+      const n = argv[i + 1]
+      if (n && !n.startsWith('--')) {
+        out[k] = n
+        i++
+      } else {
+        out[k] = true
+      }
+    }
+  }
+  return out
+}
+
+main().catch(() => { process.exitCode = 1 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,3 @@
+import { tool as transcriptTool } from './tool/transcriptYt.js'
+
+export default [transcriptTool]

--- a/src/lib/assertPlayability.ts
+++ b/src/lib/assertPlayability.ts
@@ -1,0 +1,17 @@
+/**
+ * Validates the playability status extracted from the YouTube player response.
+ * @param playabilityStatus The playabilityStatus object from player response.
+ * @returns Void when OK; throws for known unplayable states.
+ */
+export function assertPlayability(playabilityStatus: any) {
+  const status = playabilityStatus?.status
+  if (!status || status === 'OK') return
+  const reason = playabilityStatus?.reason || ''
+  if (status === 'LOGIN_REQUIRED') {
+    if (reason.includes('not a bot')) throw new Error('request_blocked')
+    if (reason.includes('inappropriate')) throw new Error('age_restricted')
+  }
+  if (status === 'ERROR' && reason.includes('unavailable')) throw new Error('video_unavailable')
+  throw new Error('video_unplayable')
+}
+

--- a/src/lib/chooseTrack.ts
+++ b/src/lib/chooseTrack.ts
@@ -1,0 +1,43 @@
+/**
+ * Chooses the most suitable caption track based on preferences and defaults.
+ * @param tracks The available caption tracks from player response.
+ * @param preferredLanguages Optional preferred languages.
+ * @param defaultCaptionTrackIndex Optional default caption track index.
+ * @param defaultTranslationSourceTrackIndices Optional default translation source indices.
+ * @returns An object with url and lang, or null when none found.
+ */
+export function chooseTrack(
+  tracks: any[],
+  preferredLanguages: string[] | undefined,
+  defaultCaptionTrackIndex: number | undefined,
+  defaultTranslationSourceTrackIndices: number[] | undefined
+) {
+  const manual = tracks.filter((t) => t.kind !== 'asr' && t.baseUrl)
+  const asr = tracks.filter((t) => t.kind === 'asr' && t.baseUrl)
+  const prefs = (preferredLanguages || []).map((x) => x.toLowerCase())
+  const scan = (list: any[]) => {
+    for (const lang of prefs) {
+      const t = list.find((x) => x.languageCode === lang || String(x.languageCode || '').toLowerCase().startsWith(lang))
+      if (t) return t
+    }
+    return undefined
+  }
+  const direct = scan(manual) || scan(asr)
+  if (direct) return { url: String(direct.baseUrl).replace('&fmt=srv3', ''), lang: direct.languageCode }
+  if (typeof defaultCaptionTrackIndex === 'number' && tracks[defaultCaptionTrackIndex]?.baseUrl) {
+    const t = tracks[defaultCaptionTrackIndex]
+    return { url: String(t.baseUrl).replace('&fmt=srv3', ''), lang: t.languageCode }
+  }
+  if (Array.isArray(defaultTranslationSourceTrackIndices)) {
+    for (const idx of defaultTranslationSourceTrackIndices) {
+      if (tracks[idx]?.baseUrl) {
+        const t = tracks[idx]
+        return { url: String(t.baseUrl).replace('&fmt=srv3', ''), lang: t.languageCode }
+      }
+    }
+  }
+  if (manual[0]) return { url: String(manual[0].baseUrl).replace('&fmt=srv3', ''), lang: manual[0].languageCode }
+  if (asr[0]) return { url: String(asr[0].baseUrl).replace('&fmt=srv3', ''), lang: asr[0].languageCode }
+  return null
+}
+

--- a/src/lib/extractInnertubeApiKey.ts
+++ b/src/lib/extractInnertubeApiKey.ts
@@ -1,0 +1,10 @@
+/**
+ * Extracts the INNERTUBE_API_KEY from a YouTube watch page HTML content.
+ * @param html The HTML string of the watch page.
+ * @returns The API key string or null when not found.
+ */
+export function extractInnertubeApiKey(html: string) {
+  const m = html.match(/\"INNERTUBE_API_KEY\":\s*\"([a-zA-Z0-9_-]+)\"/)
+  return m ? m[1] : null
+}
+

--- a/src/lib/extractVideoId.ts
+++ b/src/lib/extractVideoId.ts
@@ -1,0 +1,10 @@
+/**
+ * Extracts a YouTube video ID from a full URL or short link.
+ * @param url The YouTube video URL.
+ * @returns The 11-character video ID or null when not found.
+ */
+export function extractVideoId(url: string) {
+  const match = url.match(/(?:https?:\/\/)?(?:www\.)?(?:youtube\.com\/(?:watch\?v=|embed\/|v\/)|youtu\.be\/)([\w-]{11})/)
+  return match ? match[1] : null
+}
+

--- a/src/lib/fetchInnertubePlayer.ts
+++ b/src/lib/fetchInnertubePlayer.ts
@@ -1,0 +1,18 @@
+/**
+ * Calls the YouTube Innertube player endpoint and returns JSON.
+ * @param apiKey The Innertube API key.
+ * @param videoId The YouTube video ID.
+ * @returns The parsed JSON response object.
+ */
+export async function fetchInnertubePlayer(apiKey: string, videoId: string) {
+  const url = `https://www.youtube.com/youtubei/v1/player?key=${apiKey}`
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'Accept-Language': 'en-US' },
+    body: JSON.stringify({ context: { client: { clientName: 'ANDROID', clientVersion: '20.10.38' } }, videoId })
+  })
+  if (res.status === 429) throw new Error('ip_blocked')
+  if (!res.ok) throw new Error(`yt_request_failed_${res.status}`)
+  return res.json()
+}
+

--- a/src/lib/fetchText.ts
+++ b/src/lib/fetchText.ts
@@ -1,0 +1,12 @@
+/**
+ * Performs a GET request and returns the body as text.
+ * @param url The target URL.
+ * @param headers Optional request headers.
+ * @returns Resolves with the response text or throws on HTTP error.
+ */
+export async function fetchText(url: string, headers: Record<string, string> = {}) {
+  const res = await fetch(url, { headers })
+  if (!res.ok) throw new Error(String(res.status))
+  return res.text()
+}
+

--- a/src/lib/fetchWatchHtml.ts
+++ b/src/lib/fetchWatchHtml.ts
@@ -1,0 +1,18 @@
+import { fetchText } from './fetchText.js'
+
+/**
+ * Retrieves the YouTube watch page HTML, handling consent when necessary.
+ * @param videoId The YouTube video ID.
+ * @returns The HTML string of the watch page.
+ */
+export async function fetchWatchHtml(videoId: string) {
+  const url = `https://www.youtube.com/watch?v=${videoId}`
+  let html = await fetchText(url, { 'Accept-Language': 'en-US' })
+  if (html.includes('action="https://consent.youtube.com/s"')) {
+    const v = html.match(/name="v" value="(.*?)"/)
+    if (!v) throw new Error('consent_cookie_create_failed')
+    html = await fetchText(url, { 'Accept-Language': 'en-US', Cookie: `CONSENT=YES+${v[1]}` })
+    if (html.includes('action="https://consent.youtube.com/s"')) throw new Error('consent_cookie_invalid')
+  }
+  return html
+}

--- a/src/lib/log.ts
+++ b/src/lib/log.ts
@@ -1,0 +1,9 @@
+/**
+ * Logs a categorized error message to stderr.
+ * @param category One of: invalid_url, no_captions, inaccessible, network_error, other_error.
+ * @param message A human-readable message.
+ */
+export function logError(category: string, message: string) {
+  console.error(`${category}: ${message}`)
+}
+

--- a/src/lib/normalizeSegments.ts
+++ b/src/lib/normalizeSegments.ts
@@ -1,0 +1,21 @@
+import { TranscriptSegment } from '../types.js'
+
+/**
+ * Normalizes, deduplicates and sorts segments by start time.
+ * @param items The raw segments list.
+ * @returns Cleaned segment list.
+ */
+export function normalizeSegments(items: TranscriptSegment[]) {
+  const seen = new Set<string>()
+  const cleaned = items
+    .filter((s) => s && typeof s.text === 'string')
+    .map((s) => ({ text: s.text.trim(), startInMs: s.startInMs, duration: s.duration }))
+    .filter((s) => s.text.length > 0)
+  const dedup = cleaned.filter((s) => {
+    const k = `${s.startInMs}|${s.text}`
+    if (seen.has(k)) return false
+    seen.add(k)
+    return true
+  })
+  return dedup.sort((a, b) => a.startInMs - b.startInMs)
+}

--- a/src/lib/parseSegments.ts
+++ b/src/lib/parseSegments.ts
@@ -1,0 +1,66 @@
+import { TranscriptSegment } from '../types.js'
+
+/**
+ * Parses YouTube caption XML into normalized segments.
+ * Supports <transcript><text> and <timedtext><body><p> formats.
+ * @param xml The caption XML content.
+ * @returns The list of normalized segments.
+ */
+export function parseSegments(xml: string): TranscriptSegment[] {
+  const t1 = parseTranscriptTexts(xml)
+  if (t1.length) return t1
+  return parseTimedtext(xml)
+}
+
+/**
+ * Parses the <transcript><text> format.
+ * @param xml The XML content.
+ * @returns Segments list.
+ */
+export function parseTranscriptTexts(xml: string): TranscriptSegment[] {
+  const out: TranscriptSegment[] = []
+  const textRe = /<text[^>]*start="([^"]+)"[^>]*dur="([^"]+)"[^>]*>([\s\S]*?)<\/text>/g
+  let m: RegExpExecArray | null
+  while ((m = textRe.exec(xml)) !== null) {
+    const text = decodeHtml(String(m[3] || '')).trim()
+    if (!text) continue
+    const startMs = Math.round(Number(m[1] || 0) * 1000)
+    const durMs = Math.round(Number(m[2] || 0) * 1000)
+    out.push({ text, startInMs: startMs, duration: durMs })
+  }
+  return out
+}
+
+/**
+ * Parses the <timedtext><body><p> format.
+ * @param xml The XML content.
+ * @returns Segments list.
+ */
+export function parseTimedtext(xml: string): TranscriptSegment[] {
+  const out: TranscriptSegment[] = []
+  const pRe = /<p[^>]*\bt="(\d+)"[^>]*\bd="(\d+)"[^>]*>([\s\S]*?)<\/p>/g
+  let p: RegExpExecArray | null
+  while ((p = pRe.exec(xml)) !== null) {
+    const start = Number(p[1] || 0)
+    const duration = Number(p[2] || 0)
+    const inner = String(p[3] || '')
+    const text = decodeHtml(inner.replace(/<[^>]+>/g, '')).trim()
+    if (!text) continue
+    out.push({ text, startInMs: start, duration })
+  }
+  return out
+}
+
+/**
+ * Decodes a subset of HTML entities found in captions.
+ * @param s Input string.
+ * @returns Decoded string.
+ */
+export function decodeHtml(s: string) {
+  return s
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+}

--- a/src/tool/transcriptYt.ts
+++ b/src/tool/transcriptYt.ts
@@ -1,0 +1,91 @@
+import { TranscriptSegment, VideoTranscriptRequest } from '../types.js'
+import { extractVideoId } from '../lib/extractVideoId.js'
+import { fetchWatchHtml } from '../lib/fetchWatchHtml.js'
+import { extractInnertubeApiKey } from '../lib/extractInnertubeApiKey.js'
+import { fetchInnertubePlayer } from '../lib/fetchInnertubePlayer.js'
+import { assertPlayability } from '../lib/assertPlayability.js'
+import { chooseTrack } from '../lib/chooseTrack.js'
+import { parseSegments } from '../lib/parseSegments.js'
+import { normalizeSegments } from '../lib/normalizeSegments.js'
+import { logError } from '../lib/log.js'
+
+/**
+ * Retrieves YouTube transcript segments from a video URL.
+ * Returns null on any failure; logs categorized errors.
+ * @param args The request payload with videoUrl and optional preferredLanguages.
+ * @returns A list of transcript segments or null when unavailable.
+ */
+export async function transcriptYt(args: VideoTranscriptRequest): Promise<TranscriptSegment[] | null> {
+  try {
+    const id = extractVideoId(args.videoUrl)
+    if (!id) {
+      logError('invalid_url', 'unable_to_extract_video_id')
+      return null
+    }
+    const html = await fetchWatchHtml(id)
+    const apiKey = extractInnertubeApiKey(html)
+    if (!apiKey) {
+      logError('inaccessible', 'innertube_api_key_not_found')
+      return null
+    }
+    const data = await fetchInnertubePlayer(apiKey, id)
+    assertPlayability(data?.playabilityStatus)
+    const tracks = data?.captions?.playerCaptionsTracklistRenderer?.captionTracks || []
+    const audioTracks = data?.captions?.playerCaptionsTracklistRenderer?.audioTracks || []
+    const defaultCaptionTrackIndex = typeof audioTracks?.[0]?.defaultCaptionTrackIndex === 'number' ? audioTracks[0].defaultCaptionTrackIndex : undefined
+    const defaultTranslationSourceTrackIndices = data?.captions?.playerCaptionsTracklistRenderer?.defaultTranslationSourceTrackIndices as number[] | undefined
+    if (!Array.isArray(tracks) || tracks.length === 0) {
+      logError('no_captions', 'no_caption_tracks_found')
+      return null
+    }
+    const picked = chooseTrack(tracks, args.preferredLanguages, defaultCaptionTrackIndex, defaultTranslationSourceTrackIndices)
+    if (!picked) {
+      logError('no_captions', 'no_suitable_track_found')
+      return null
+    }
+    const xml = await fetch(picked.url, { headers: { 'Accept-Language': 'en-US' } }).then((r) => {
+      if (!r.ok) throw new Error(String(r.status))
+      return r.text()
+    })
+    const segments = normalizeSegments(parseSegments(xml))
+    if (!segments.length) {
+      logError('no_captions', 'no_segments_after_parsing')
+      return null
+    }
+    return segments
+  } catch (err: any) {
+    const msg = String(err?.message || 'unknown_error')
+    if (msg.includes('yt_request_failed_') || msg === 'ip_blocked') logError('network_error', msg)
+    else if (msg === 'video_unavailable' || msg === 'video_unplayable' || msg === 'age_restricted' || msg === 'request_blocked') logError('inaccessible', msg)
+    else logError('other_error', msg)
+    return null
+  }
+}
+
+export const tool = ['transcript_yt', {
+  schema: {
+    type: 'function',
+    function: {
+      name: 'transcript_yt',
+      description: 'Fetches YouTube transcript segments from a video URL for LLM consumption.',
+      parameters: {
+        type: 'object',
+        properties: {
+          videoUrl: { type: 'string', description: 'Full YouTube video URL.' },
+          preferredLanguages: { type: 'array', items: { type: 'string' }, description: "Optional ordered language codes preference, e.g., ['pt-BR','en']." }
+        },
+        required: ['videoUrl'],
+        additionalProperties: false
+      },
+      strict: true
+    }
+  },
+  fn: async (args: VideoTranscriptRequest): Promise<TranscriptSegment[] | null> => transcriptYt(args)
+}]
+
+export const __testables = {
+  extractVideoId,
+  extractInnertubeApiKey,
+  chooseTrack,
+  parseSegments
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,11 @@
+export type TranscriptSegment = {
+  text: string
+  startInMs: number
+  duration: number
+}
+
+export type VideoTranscriptRequest = {
+  videoUrl: string
+  preferredLanguages?: string[]
+}
+

--- a/tests/integration/fallback_asr.test.ts
+++ b/tests/integration/fallback_asr.test.ts
@@ -1,0 +1,39 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { transcriptYt } from '../../src/tool/transcriptYt.js'
+
+test('integration: falls back to ASR when manual missing', async () => {
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = (async (input: any) => {
+    const url = typeof input === 'string' ? input : String(input?.url || '')
+    if (url.startsWith('https://www.youtube.com/watch')) {
+      return mkResponse(200, '<html>"INNERTUBE_API_KEY":"abc123"</html>')
+    }
+    if (url.startsWith('https://www.youtube.com/youtubei/v1/player?key=')) {
+      const body = JSON.stringify({
+        playabilityStatus: { status: 'OK' },
+        captions: {
+          playerCaptionsTracklistRenderer: {
+            captionTracks: [ { kind: 'asr', languageCode: 'en', baseUrl: 'https://example/track_en_asr' } ],
+            audioTracks: [ { defaultCaptionTrackIndex: 0 } ]
+          }
+        }
+      })
+      return mkResponse(200, body, 'application/json')
+    }
+    if (url === 'https://example/track_en_asr') {
+      return mkResponse(200, '<transcript><text start="0.0" dur="1.5">Hello</text></transcript>')
+    }
+    return mkResponse(404, 'not found')
+  }) as any
+
+  const res = await transcriptYt({ videoUrl: 'https://youtu.be/dQw4w9WgXcQ', preferredLanguages: ['pt-BR', 'en'] })
+  assert.ok(Array.isArray(res))
+  assert.equal(res?.[0].text, 'Hello')
+
+  globalThis.fetch = originalFetch as any
+})
+
+function mkResponse(status: number, body: string, contentType = 'text/html') {
+  return new Response(body, { status, headers: { 'content-type': contentType } })
+}

--- a/tests/integration/inaccessible.test.ts
+++ b/tests/integration/inaccessible.test.ts
@@ -1,0 +1,47 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { transcriptYt } from '../../src/tool/transcriptYt.js'
+
+test('integration: age restricted returns null', async () => {
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = (async (input: any) => {
+    const url = typeof input === 'string' ? input : String(input?.url || '')
+    if (url.startsWith('https://www.youtube.com/watch')) {
+      return mkResponse(200, '<html>"INNERTUBE_API_KEY":"abc123"</html>')
+    }
+    if (url.startsWith('https://www.youtube.com/youtubei/v1/player?key=')) {
+      const body = JSON.stringify({ playabilityStatus: { status: 'LOGIN_REQUIRED', reason: 'This video is inappropriate for some users' } })
+      return mkResponse(200, body, 'application/json')
+    }
+    return mkResponse(404, 'not found')
+  }) as any
+
+  const res = await transcriptYt({ videoUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' })
+  assert.equal(res, null)
+
+  globalThis.fetch = originalFetch as any
+})
+
+test('integration: unavailable returns null', async () => {
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = (async (input: any) => {
+    const url = typeof input === 'string' ? input : String(input?.url || '')
+    if (url.startsWith('https://www.youtube.com/watch')) {
+      return mkResponse(200, '<html>"INNERTUBE_API_KEY":"abc123"</html>')
+    }
+    if (url.startsWith('https://www.youtube.com/youtubei/v1/player?key=')) {
+      const body = JSON.stringify({ playabilityStatus: { status: 'ERROR', reason: 'Video unavailable' } })
+      return mkResponse(200, body, 'application/json')
+    }
+    return mkResponse(404, 'not found')
+  }) as any
+
+  const res = await transcriptYt({ videoUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' })
+  assert.equal(res, null)
+
+  globalThis.fetch = originalFetch as any
+})
+
+function mkResponse(status: number, body: string, contentType = 'text/html') {
+  return new Response(body, { status, headers: { 'content-type': contentType } })
+}

--- a/tests/integration/invalid_url.test.ts
+++ b/tests/integration/invalid_url.test.ts
@@ -1,0 +1,8 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { transcriptYt } from '../../src/tool/transcriptYt.js'
+
+test('integration: invalid URL returns null', async () => {
+  const res = await transcriptYt({ videoUrl: 'https://example.com/watch?v=xyz' })
+  assert.equal(res, null)
+})

--- a/tests/integration/language_prefix.test.ts
+++ b/tests/integration/language_prefix.test.ts
@@ -1,0 +1,42 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { transcriptYt } from '../../src/tool/transcriptYt.js'
+
+test('integration: language prefix matches (pt -> pt-BR)', async () => {
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = (async (input: any) => {
+    const url = typeof input === 'string' ? input : String(input?.url || '')
+    if (url.startsWith('https://www.youtube.com/watch')) {
+      return mkResponse(200, '<html>"INNERTUBE_API_KEY":"abc123"</html>')
+    }
+    if (url.startsWith('https://www.youtube.com/youtubei/v1/player?key=')) {
+      const body = JSON.stringify({
+        playabilityStatus: { status: 'OK' },
+        captions: {
+          playerCaptionsTracklistRenderer: {
+            captionTracks: [
+              { kind: 'standard', languageCode: 'pt-BR', baseUrl: 'https://example/track_pt' },
+              { kind: 'standard', languageCode: 'en', baseUrl: 'https://example/track_en' }
+            ],
+            audioTracks: [ { defaultCaptionTrackIndex: 0 } ]
+          }
+        }
+      })
+      return mkResponse(200, body, 'application/json')
+    }
+    if (url === 'https://example/track_pt') {
+      return mkResponse(200, '<transcript><text start="0.0" dur="1.0">Oi</text></transcript>')
+    }
+    return mkResponse(404, 'not found')
+  }) as any
+
+  const res = await transcriptYt({ videoUrl: 'https://youtu.be/dQw4w9WgXcQ', preferredLanguages: ['pt'] })
+  assert.ok(Array.isArray(res))
+  assert.equal(res?.[0].text, 'Oi')
+
+  globalThis.fetch = originalFetch as any
+})
+
+function mkResponse(status: number, body: string, contentType = 'text/html') {
+  return new Response(body, { status, headers: { 'content-type': contentType } })
+}

--- a/tests/integration/no_captions.test.ts
+++ b/tests/integration/no_captions.test.ts
@@ -1,0 +1,27 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { transcriptYt } from '../../src/tool/transcriptYt.js'
+
+test('integration: returns null when no captions', async () => {
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = (async (input: any) => {
+    const url = typeof input === 'string' ? input : String(input?.url || '')
+    if (url.startsWith('https://www.youtube.com/watch')) {
+      return mkResponse(200, '<html>"INNERTUBE_API_KEY":"abc123"</html>')
+    }
+    if (url.startsWith('https://www.youtube.com/youtubei/v1/player?key=')) {
+      const body = JSON.stringify({ playabilityStatus: { status: 'OK' } })
+      return mkResponse(200, body, 'application/json')
+    }
+    return mkResponse(404, 'not found')
+  }) as any
+
+  const res = await transcriptYt({ videoUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' })
+  assert.equal(res, null)
+
+  globalThis.fetch = originalFetch as any
+})
+
+function mkResponse(status: number, body: string, contentType = 'text/html') {
+  return new Response(body, { status, headers: { 'content-type': contentType } })
+}

--- a/tests/integration/preferred_missing_manual.test.ts
+++ b/tests/integration/preferred_missing_manual.test.ts
@@ -1,0 +1,42 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { transcriptYt } from '../../src/tool/transcriptYt.js'
+
+test('integration: when preferred language missing, picks first manual available', async () => {
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = (async (input: any) => {
+    const url = typeof input === 'string' ? input : String(input?.url || '')
+    if (url.startsWith('https://www.youtube.com/watch')) {
+      return mkResponse(200, '<html>"INNERTUBE_API_KEY":"abc123"</html>')
+    }
+    if (url.startsWith('https://www.youtube.com/youtubei/v1/player?key=')) {
+      const body = JSON.stringify({
+        playabilityStatus: { status: 'OK' },
+        captions: {
+          playerCaptionsTracklistRenderer: {
+            captionTracks: [
+              { kind: 'standard', languageCode: 'es', baseUrl: 'https://example/track_es' },
+              { kind: 'asr', languageCode: 'en', baseUrl: 'https://example/track_en_asr' }
+            ],
+            audioTracks: [ { defaultCaptionTrackIndex: 0 } ]
+          }
+        }
+      })
+      return mkResponse(200, body, 'application/json')
+    }
+    if (url === 'https://example/track_es') {
+      return mkResponse(200, '<transcript><text start="0.0" dur="1.0">Hola</text></transcript>')
+    }
+    return mkResponse(404, 'not found')
+  }) as any
+
+  const res = await transcriptYt({ videoUrl: 'https://youtu.be/dQw4w9WgXcQ', preferredLanguages: ['pt-BR'] })
+  assert.ok(Array.isArray(res))
+  assert.equal(res?.[0].text, 'Hola')
+
+  globalThis.fetch = originalFetch as any
+})
+
+function mkResponse(status: number, body: string, contentType = 'text/html') {
+  return new Response(body, { status, headers: { 'content-type': contentType } })
+}

--- a/tests/integration/repeated_calls.test.ts
+++ b/tests/integration/repeated_calls.test.ts
@@ -1,0 +1,43 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { transcriptYt } from '../../src/tool/transcriptYt.js'
+
+test('integration: repeated calls perform fresh fetches (no cache)', async () => {
+  let playerCalls = 0
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = (async (input: any, init?: any) => {
+    const url = typeof input === 'string' ? input : String(input?.url || '')
+    if (url.startsWith('https://www.youtube.com/watch')) {
+      return mkResponse(200, '<html>"INNERTUBE_API_KEY":"abc123"</html>')
+    }
+    if (url.startsWith('https://www.youtube.com/youtubei/v1/player?key=')) {
+      playerCalls++
+      const body = JSON.stringify({
+        playabilityStatus: { status: 'OK' },
+        captions: {
+          playerCaptionsTracklistRenderer: {
+            captionTracks: [ { kind: 'standard', languageCode: 'en', baseUrl: 'https://example/track_en' } ],
+            audioTracks: [ { defaultCaptionTrackIndex: 0 } ]
+          }
+        }
+      })
+      return mkResponse(200, body, 'application/json')
+    }
+    if (url === 'https://example/track_en') {
+      return mkResponse(200, '<transcript><text start="0.0" dur="1.0">Hi</text></transcript>')
+    }
+    return mkResponse(404, 'not found')
+  }) as any
+
+  const url = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
+  const a = await transcriptYt({ videoUrl: url })
+  const b = await transcriptYt({ videoUrl: url })
+  assert.equal(playerCalls >= 2, true)
+  assert.ok(Array.isArray(a) && Array.isArray(b))
+
+  globalThis.fetch = originalFetch as any
+})
+
+function mkResponse(status: number, body: string, contentType = 'text/html') {
+  return new Response(body, { status, headers: { 'content-type': contentType } })
+}

--- a/tests/integration/success_manual.test.ts
+++ b/tests/integration/success_manual.test.ts
@@ -1,0 +1,45 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { transcriptYt } from '../../src/tool/transcriptYt.js'
+
+test('integration: returns segments from manual track in preferred language', async () => {
+  const calls: string[] = []
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = (async (input: any, init?: any) => {
+    const url = typeof input === 'string' ? input : String(input?.url || '')
+    calls.push(url)
+    if (url.startsWith('https://www.youtube.com/watch')) {
+      return mkResponse(200, '<html>"INNERTUBE_API_KEY":"abc123"</html>')
+    }
+    if (url.startsWith('https://www.youtube.com/youtubei/v1/player?key=')) {
+      const body = JSON.stringify({
+        playabilityStatus: { status: 'OK' },
+        captions: {
+          playerCaptionsTracklistRenderer: {
+            captionTracks: [
+              { kind: 'standard', languageCode: 'pt-BR', baseUrl: 'https://example/track_pt' },
+              { kind: 'asr', languageCode: 'en', baseUrl: 'https://example/track_en_asr' }
+            ],
+            audioTracks: [ { defaultCaptionTrackIndex: 0 } ]
+          }
+        }
+      })
+      return mkResponse(200, body, 'application/json')
+    }
+    if (url === 'https://example/track_pt') {
+      return mkResponse(200, '<transcript><text start="0.0" dur="1.0">Olá</text></transcript>')
+    }
+    return mkResponse(404, 'not found')
+  }) as any
+
+  const res = await transcriptYt({ videoUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ', preferredLanguages: ['pt-BR', 'en'] })
+  assert.ok(Array.isArray(res))
+  assert.equal(res?.length, 1)
+  assert.deepEqual(res?.[0], { text: 'Olá', startInMs: 0, duration: 1000 })
+
+  globalThis.fetch = originalFetch as any
+})
+
+function mkResponse(status: number, body: string, contentType = 'text/html') {
+  return new Response(body, { status, headers: { 'content-type': contentType } })
+}

--- a/tests/unit/chooseTrack.test.ts
+++ b/tests/unit/chooseTrack.test.ts
@@ -1,0 +1,29 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { __testables } from '../../src/tool/transcriptYt.js'
+
+test('chooseTrack: prefers manual in preferred language', () => {
+  const tracks = [
+    { kind: 'asr', languageCode: 'en', baseUrl: 'u1' },
+    { kind: 'standard', languageCode: 'pt-BR', baseUrl: 'u2' }
+  ]
+  const picked = __testables.chooseTrack(tracks, ['pt-BR', 'en'], undefined, undefined)
+  assert.deepEqual(picked, { url: 'u2', lang: 'pt-BR' })
+})
+
+test('chooseTrack: falls back to ASR when manual missing', () => {
+  const tracks = [
+    { kind: 'asr', languageCode: 'en', baseUrl: 'u1' }
+  ]
+  const picked = __testables.chooseTrack(tracks, ['en'], undefined, undefined)
+  assert.deepEqual(picked, { url: 'u1', lang: 'en' })
+})
+
+test('chooseTrack: uses default indices when no preferred', () => {
+  const tracks = [
+    { kind: 'standard', languageCode: 'en', baseUrl: 'u1' },
+    { kind: 'standard', languageCode: 'es', baseUrl: 'u2' }
+  ]
+  const picked = __testables.chooseTrack(tracks, [], 1, undefined)
+  assert.deepEqual(picked, { url: 'u2', lang: 'es' })
+})

--- a/tests/unit/extractVideoId.test.ts
+++ b/tests/unit/extractVideoId.test.ts
@@ -1,0 +1,18 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { __testables } from '../../src/tool/transcriptYt.js'
+
+test('extractVideoId: valid full URL', () => {
+  const id = __testables.extractVideoId('https://www.youtube.com/watch?v=dQw4w9WgXcQ')
+  assert.equal(id, 'dQw4w9WgXcQ')
+})
+
+test('extractVideoId: valid youtu.be short URL', () => {
+  const id = __testables.extractVideoId('https://youtu.be/dQw4w9WgXcQ')
+  assert.equal(id, 'dQw4w9WgXcQ')
+})
+
+test('extractVideoId: invalid URL', () => {
+  const id = __testables.extractVideoId('https://example.com')
+  assert.equal(id, null)
+})

--- a/tests/unit/normalizeSegments.test.ts
+++ b/tests/unit/normalizeSegments.test.ts
@@ -1,0 +1,15 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { normalizeSegments } from '../../src/lib/normalizeSegments.js'
+
+test('normalizeSegments: trims, dedups and sorts', () => {
+  const segs = normalizeSegments([
+    { text: 'B', startInMs: 2000, duration: 500 },
+    { text: ' A ', startInMs: 0, duration: 1000 },
+    { text: 'B', startInMs: 2000, duration: 500 },
+    { text: ' ', startInMs: 1500, duration: 300 }
+  ])
+  assert.equal(segs.length, 2)
+  assert.deepEqual(segs[0], { text: 'A', startInMs: 0, duration: 1000 })
+  assert.deepEqual(segs[1], { text: 'B', startInMs: 2000, duration: 500 })
+})

--- a/tests/unit/parseSegments.test.ts
+++ b/tests/unit/parseSegments.test.ts
@@ -1,0 +1,19 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { __testables } from '../../src/tool/transcriptYt.js'
+
+test('parseSegments: transcript/text format', () => {
+  const xml = '<transcript><text start="0.0" dur="2.3">Hello &amp; welcome</text><text start="2.3" dur="1.8">World</text></transcript>'
+  const segs = __testables.parseSegments(xml)
+  assert.equal(segs.length, 2)
+  assert.deepEqual(segs[0], { text: 'Hello & welcome', startInMs: 0, duration: 2300 })
+  assert.deepEqual(segs[1], { text: 'World', startInMs: 2300, duration: 1800 })
+})
+
+test('parseSegments: timedtext/p format', () => {
+  const xml = '<timedtext><body><p t="0" d="2300">Hello<s> </s>World</p><p t="2300" d="1800">Again</p></body></timedtext>'
+  const segs = __testables.parseSegments(xml)
+  assert.equal(segs.length, 2)
+  assert.deepEqual(segs[0], { text: 'Hello World', startInMs: 0, duration: 2300 })
+  assert.deepEqual(segs[1], { text: 'Again', startInMs: 2300, duration: 1800 })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "newLine": "lf",
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"]
+  },
+  "include": ["src", "tests"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
This pull request introduces the initial implementation and documentation for the YouTube Transcript MCP Tool, a Model Context Protocol (MCP) utility that fetches YouTube video transcripts for LLM integration. The changes establish the project's structure, usage instructions, data model, and technical decisions, and add the main tool logic for transcript extraction and error handling.

**Project Documentation and Usage**

* Added a comprehensive `README.md` detailing the tool's purpose, usage via npx, MCP server configuration, programmatic integration, and design guarantees.
* Created a quickstart guide (`specs/001-criar-mcp-que/quickstart.md`) with installation, configuration, sample input/output, error behavior, and testing expectations.

**Technical Design and Planning**

* Documented the implementation plan (`specs/001-criar-mcp-que/plan.md`), outlining execution phases, technical context, project structure, and testing strategy.
* Provided a research summary (`specs/001-criar-mcp-que/research.md`) justifying design choices such as no caching, minimal dependencies, and error handling categories.

**Data Model and Contracts**

* Defined the data model (`specs/001-criar-mcp-que/data-model.md`) for transcript requests and segments, including validation flow and error conditions.
* Added a contracts note (`specs/001-criar-mcp-que/contracts/README.md`) clarifying that no external HTTP endpoints are exposed; the tool is available via MCP only.

**Main Tool Implementation**

* Implemented the core transcript extraction logic in `example.ts`, including YouTube URL parsing, API interaction, caption track selection, XML parsing for segments, and robust error handling returning `null` on failure.

**Project Setup**

* Added `package.json` specifying package metadata, entry points, dependencies, and scripts for building and testing the tool.