### PR TITLE
mcp: address review feedback for v1.0.0

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,5 +7,11 @@ export default [
       quotes: ['error', 'single', { avoidEscape: true }],
       indent: ['error', 2]
     }
+  },
+  {
+    files: ['tests/**/*.js'],
+    languageOptions: {
+      globals: { fetch: 'readonly', Response: 'readonly' }
+    }
   }
 ]

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "test": "node --test tests/**/*.test.js",
-    "lint": "eslint ."
+    "lint": "eslint . --max-warnings=0"
   },
   "engines": {
     "node": ">=18"

--- a/src/tool/transcriptYt.js
+++ b/src/tool/transcriptYt.js
@@ -43,7 +43,7 @@ export async function transcriptYt(args) {
       return null
     }
     const xml = await fetch(picked.url, { headers: { 'Accept-Language': 'en-US' } }).then((r) => {
-      if (!r.ok) throw new Error(String(r.status))
+      if (!r.ok) throw new Error(`yt_request_failed_${r.status}`)
       return r.text()
     })
     const segments = normalizeSegments(parseSegments(xml))
@@ -53,10 +53,10 @@ export async function transcriptYt(args) {
     }
     return segments
   } catch (err) {
-    const msg = String(err?.message || '')
+    const msg = typeof err?.message === 'string' ? err.message : ''
     if (msg.includes('yt_request_failed_') || msg === 'ip_blocked') logError('network_error', msg)
     else if (msg === 'video_unavailable' || msg === 'video_unplayable' || msg === 'age_restricted' || msg === 'request_blocked') logError('inaccessible', msg)
-    else logError('other_error', 'unexpected_error')
+    else logError('other_error', msg || 'unexpected_error')
     return null
   }
 }

--- a/tests/integration/dedup.test.js
+++ b/tests/integration/dedup.test.js
@@ -4,37 +4,39 @@ import { transcriptYt } from '../../src/tool/transcriptYt.js'
 
 test('integration: duplicate segments removed', async () => {
   const originalFetch = globalThis.fetch
-  globalThis.fetch = (async (input) => {
-    const url = typeof input === 'string' ? input : String(input?.url || '')
-    if (url.startsWith('https://www.youtube.com/watch')) {
-      return mkResponse(200, '<html>"INNERTUBE_API_KEY":"abc123"</html>')
-    }
-    if (url.startsWith('https://www.youtube.com/youtubei/v1/player?key=')) {
-      const body = JSON.stringify({
-        playabilityStatus: { status: 'OK' },
-        captions: {
-          playerCaptionsTracklistRenderer: {
-            captionTracks: [
-              { kind: 'standard', languageCode: 'en', baseUrl: 'https://example/track_en' }
-            ],
-            audioTracks: [ { defaultCaptionTrackIndex: 0 } ]
+  try {
+    globalThis.fetch = async (input) => {
+      const url = typeof input === 'string' ? input : String(input?.url || '')
+      if (url.startsWith('https://www.youtube.com/watch')) {
+        return mkResponse(200, '<html>"INNERTUBE_API_KEY":"abc123"</html>')
+      }
+      if (url.startsWith('https://www.youtube.com/youtubei/v1/player?key=')) {
+        const body = JSON.stringify({
+          playabilityStatus: { status: 'OK' },
+          captions: {
+            playerCaptionsTracklistRenderer: {
+              captionTracks: [
+                { kind: 'standard', languageCode: 'en', baseUrl: 'https://example/track_en' }
+              ],
+              audioTracks: [ { defaultCaptionTrackIndex: 0 } ]
+            }
           }
-        }
-      })
-      return mkResponse(200, body, 'application/json')
+        })
+        return mkResponse(200, body, 'application/json')
+      }
+      if (url === 'https://example/track_en') {
+        return mkResponse(200, '<transcript><text start="0.0" dur="1.0">Hi</text><text start="0.0" dur="1.0">Hi</text></transcript>')
+      }
+      return mkResponse(404, 'not found')
     }
-    if (url === 'https://example/track_en') {
-      return mkResponse(200, '<transcript><text start="0.0" dur="1.0">Hi</text><text start="0.0" dur="1.0">Hi</text></transcript>')
-    }
-    return mkResponse(404, 'not found')
-  })
 
-  const res = await transcriptYt({ videoUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' })
-  assert.ok(Array.isArray(res))
-  assert.equal(res?.length, 1)
-  assert.deepEqual(res?.[0], { text: 'Hi', startInMs: 0, duration: 1000 })
-
-  globalThis.fetch = originalFetch
+    const res = await transcriptYt({ videoUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' })
+    assert.ok(Array.isArray(res))
+    assert.equal(res?.length, 1)
+    assert.deepEqual(res?.[0], { text: 'Hi', startInMs: 0, duration: 1000 })
+  } finally {
+    globalThis.fetch = originalFetch
+  }
 })
 
 function mkResponse(status, body, contentType = 'text/html') {

--- a/tests/integration/long_video.test.js
+++ b/tests/integration/long_video.test.js
@@ -4,36 +4,38 @@ import { transcriptYt } from '../../src/tool/transcriptYt.js'
 
 test('integration: large transcript not truncated', async () => {
   const originalFetch = globalThis.fetch
-  globalThis.fetch = async (input) => {
-    const url = typeof input === 'string' ? input : String(input?.url || '')
-    if (url.startsWith('https://www.youtube.com/watch')) {
-      return mkResponse(200, '<html>"INNERTUBE_API_KEY":"abc123"</html>')
-    }
-    if (url.startsWith('https://www.youtube.com/youtubei/v1/player?key=')) {
-      const body = JSON.stringify({
-        playabilityStatus: { status: 'OK' },
-        captions: {
-          playerCaptionsTracklistRenderer: {
-            captionTracks: [
-              { kind: 'standard', languageCode: 'en', baseUrl: 'https://example/track_en' }
-            ],
-            audioTracks: [ { defaultCaptionTrackIndex: 0 } ]
+  try {
+    globalThis.fetch = async (input) => {
+      const url = typeof input === 'string' ? input : String(input?.url || '')
+      if (url.startsWith('https://www.youtube.com/watch')) {
+        return mkResponse(200, '<html>"INNERTUBE_API_KEY":"abc123"</html>')
+      }
+      if (url.startsWith('https://www.youtube.com/youtubei/v1/player?key=')) {
+        const body = JSON.stringify({
+          playabilityStatus: { status: 'OK' },
+          captions: {
+            playerCaptionsTracklistRenderer: {
+              captionTracks: [
+                { kind: 'standard', languageCode: 'en', baseUrl: 'https://example/track_en' }
+              ],
+              audioTracks: [ { defaultCaptionTrackIndex: 0 } ]
+            }
           }
-        }
-      })
-      return mkResponse(200, body, 'application/json')
+        })
+        return mkResponse(200, body, 'application/json')
+      }
+      if (url === 'https://example/track_en') {
+        return mkResponse(200, mkTranscript(1000))
+      }
+      return mkResponse(404, 'not found')
     }
-    if (url === 'https://example/track_en') {
-      return mkResponse(200, mkTranscript(1000))
-    }
-    return mkResponse(404, 'not found')
+
+    const res = await transcriptYt({ videoUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' })
+    assert.ok(Array.isArray(res))
+    assert.equal(res.length, 1000)
+  } finally {
+    globalThis.fetch = originalFetch
   }
-
-  const res = await transcriptYt({ videoUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' })
-  assert.ok(Array.isArray(res))
-  assert.equal(res.length, 1000)
-
-  globalThis.fetch = originalFetch
 })
 
 /**
@@ -53,9 +55,9 @@ function mkResponse(status, body, contentType = 'text/html') {
  * @returns Transcript XML.
  */
 function mkTranscript(count) {
-  let xml = '<transcript>'
+  const parts = new Array(count)
   for (let i = 0; i < count; i++) {
-    xml += `<text start="${i}.0" dur="1.0">S${i}</text>`
+    parts[i] = `<text start="${i}.0" dur="1.0">S${i}</text>`
   }
-  return xml + '</transcript>'
+  return `<transcript>${parts.join('')}</transcript>`
 }

--- a/tests/integration/no_preferred.test.js
+++ b/tests/integration/no_preferred.test.js
@@ -4,37 +4,39 @@ import { transcriptYt } from '../../src/tool/transcriptYt.js'
 
 test('integration: when no preferredLanguages provided, uses default track', async () => {
   const originalFetch = globalThis.fetch
-  globalThis.fetch = (async (input) => {
-    const url = typeof input === 'string' ? input : String(input?.url || '')
-    if (url.startsWith('https://www.youtube.com/watch')) {
-      return mkResponse(200, '<html>"INNERTUBE_API_KEY":"abc123"</html>')
-    }
-    if (url.startsWith('https://www.youtube.com/youtubei/v1/player?key=')) {
-      const body = JSON.stringify({
-        playabilityStatus: { status: 'OK' },
-        captions: {
-          playerCaptionsTracklistRenderer: {
-            captionTracks: [
-              { kind: 'asr', languageCode: 'en', baseUrl: 'https://example/track_en_asr' },
-              { kind: 'standard', languageCode: 'pt-BR', baseUrl: 'https://example/track_pt' }
-            ],
-            audioTracks: [ { defaultCaptionTrackIndex: 1 } ]
+  try {
+    globalThis.fetch = async (input) => {
+      const url = typeof input === 'string' ? input : String(input?.url || '')
+      if (url.startsWith('https://www.youtube.com/watch')) {
+        return mkResponse(200, '<html>"INNERTUBE_API_KEY":"abc123"</html>')
+      }
+      if (url.startsWith('https://www.youtube.com/youtubei/v1/player?key=')) {
+        const body = JSON.stringify({
+          playabilityStatus: { status: 'OK' },
+          captions: {
+            playerCaptionsTracklistRenderer: {
+              captionTracks: [
+                { kind: 'asr', languageCode: 'en', baseUrl: 'https://example/track_en_asr' },
+                { kind: 'standard', languageCode: 'pt-BR', baseUrl: 'https://example/track_pt' }
+              ],
+              audioTracks: [ { defaultCaptionTrackIndex: 1 } ]
+            }
           }
-        }
-      })
-      return mkResponse(200, body, 'application/json')
+        })
+        return mkResponse(200, body, 'application/json')
+      }
+      if (url === 'https://example/track_pt') {
+        return mkResponse(200, '<transcript><text start="0.0" dur="1.0">Olá</text></transcript>')
+      }
+      return mkResponse(404, 'not found')
     }
-    if (url === 'https://example/track_pt') {
-      return mkResponse(200, '<transcript><text start="0.0" dur="1.0">Olá</text></transcript>')
-    }
-    return mkResponse(404, 'not found')
-  })
 
-  const res = await transcriptYt({ videoUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' })
-  assert.ok(Array.isArray(res))
-  assert.equal(res?.[0].text, 'Olá')
-
-  globalThis.fetch = originalFetch
+    const res = await transcriptYt({ videoUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' })
+    assert.ok(Array.isArray(res))
+    assert.equal(res?.[0].text, 'Olá')
+  } finally {
+    globalThis.fetch = originalFetch
+  }
 })
 
 function mkResponse(status, body, contentType = 'text/html') {


### PR DESCRIPTION
## Summary
- enforce zero-warning lint and define test globals
- restore global fetch in integration tests and optimize transcript builder
- improve network error logging and message handling

## Testing
- `npm test`
- `npm run lint`
- `npm install` *(fails: 403 Forbidden to registry)*

------
https://chatgpt.com/codex/tasks/task_e_68c370f531d48333adf680f0023f9201